### PR TITLE
RdfStore instead of N3store, and changed types to RDFJS types

### DIFF
--- a/bin/extract.ts
+++ b/bin/extract.ts
@@ -1,6 +1,7 @@
 import * as process from 'process';
 import { CBDShapeExtractor } from '../lib/CBDShapeExtractor';
-import {Store, Writer, NamedNode} from 'n3';
+import {Writer, NamedNode} from 'n3';
+import { RdfStore } from 'rdf-stores';
 import rdfDereference from 'rdf-dereference';
 
 // Check if at least one command line argument is provided
@@ -11,7 +12,7 @@ if (process.argv.length <= 2) {
 async function main () {
     // Get the command line parameter at index 2 (index 0 is the node executable and index 1 is the script file)
     const entity = process.argv[2];
-    let shapeStore:Store = new Store();
+    let shapeStore:RdfStore = RdfStore.createDefault();
     let shapeId = "";
     if (process.argv[3]) {
         //A shape type has been set!
@@ -36,7 +37,7 @@ async function main () {
     let extractor = new CBDShapeExtractor(shapeStore);
     console.error('Processing shape ' + shapeId + ' from this shape: ', extractor.shapesGraph);
     let writer = new Writer();
-    let quads = await extractor.extract(new Store(), new NamedNode(entity), new NamedNode(shapeId));
+    let quads = await extractor.extract(RdfStore.createDefault(), new NamedNode(entity), new NamedNode(shapeId));
     writer.addQuads(quads);
     writer.end((err, res) => {console.log(res);});
 }

--- a/lib/Path.ts
+++ b/lib/Path.ts
@@ -1,5 +1,5 @@
 import { Quad, Term } from "@rdfjs/types";
-import { Store } from "n3";
+import { RdfStore } from "rdf-stores";
 import { CbdExtracted, Extracted } from "./CBDShapeExtractor";
 
 export interface Path {
@@ -8,7 +8,7 @@ export interface Path {
   found(cbd: CbdExtracted, inverse?: boolean): CbdExtracted | undefined;
 
   match(
-    store: Store,
+    store: RdfStore,
     extracted: CbdExtracted,
     focusNode: Term,
     graphsToIgnore?: Array<string>,
@@ -32,7 +32,7 @@ export class PredicatePath implements Path {
   }
 
   match(
-    store: Store,
+    store: RdfStore,
     extracted: CbdExtracted,
     focusNode: Term,
     graphsToIgnore: Array<string>,
@@ -79,7 +79,7 @@ export class SequencePath implements Path {
   }
 
   match(
-    store: Store,
+    store: RdfStore,
     extracted: CbdExtracted,
     focusNode: Term,
     graphsToIgnore: Array<string>,
@@ -132,7 +132,7 @@ export class AlternativePath implements Path {
   }
 
   match(
-    store: Store,
+    store: RdfStore,
     extracted: CbdExtracted,
     focusNode: Term,
     graphsToIgnore: Array<string>,
@@ -160,7 +160,7 @@ export class InversePath implements Path {
   }
 
   match(
-    store: Store,
+    store: RdfStore,
     extracted: CbdExtracted,
     focusNode: Term,
     graphsToIgnore: Array<string>,
@@ -190,7 +190,7 @@ export abstract class MultiPath implements Path {
   abstract found(cbd: CbdExtracted): CbdExtracted | undefined;
 
   match(
-    store: Store,
+    store: RdfStore,
     extracted: CbdExtracted,
     focusNode: Term,
     graphsToIgnore: Array<string>,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,19 @@
 {
   "name": "extract-cbd-shape",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "extract-cbd-shape",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "@treecg/types": "^0.4.5",
         "jsdom": "^23.0.1",
-        "n3": "^1.17.0"
+        "n3": "^1.17.0",
+        "rdf-data-factory": "^1.1.2",
+        "rdf-stores": "^1.0.0"
       },
       "devDependencies": {
         "@rdfjs/types": "*",
@@ -788,8 +790,7 @@
     "node_modules/asynciterator": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.8.1.tgz",
-      "integrity": "sha512-SmdG0FUY3pYGOZZGdYq8Qb/DCRDXBFZUk08V1/4lbBXdAQvcC3Kxzz9FUDPBTik7VAVltt4cZirAPtJv3gOpEw==",
-      "peer": true
+      "integrity": "sha512-SmdG0FUY3pYGOZZGdYq8Qb/DCRDXBFZUk08V1/4lbBXdAQvcC3Kxzz9FUDPBTik7VAVltt4cZirAPtJv3gOpEw=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -2219,11 +2220,22 @@
         "@rdfjs/types": "*"
       }
     },
+    "node_modules/rdf-stores": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-stores/-/rdf-stores-1.0.0.tgz",
+      "integrity": "sha512-wqp7M5409rbhpWQE0C1vyVysbz++aD2vEkZ6yueSxhDtyLvznS41R3cKiuUpm3ikc/yTpaCZwPo4iyKEaAwBIg==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.2",
+        "rdf-terms": "^1.9.1"
+      }
+    },
     "node_modules/rdf-string": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
       "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
-      "peer": true,
       "dependencies": {
         "@rdfjs/types": "*",
         "rdf-data-factory": "^1.1.0"
@@ -2233,7 +2245,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.11.0.tgz",
       "integrity": "sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==",
-      "peer": true,
       "dependencies": {
         "@rdfjs/types": "*",
         "rdf-data-factory": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "dependencies": {
     "@treecg/types": "^0.4.5",
     "jsdom": "^23.0.1",
-    "n3": "^1.17.0"
+    "n3": "^1.17.0",
+    "rdf-data-factory": "^1.1.2",
+    "rdf-stores": "^1.0.0"
   },
   "devDependencies": {
     "@rdfjs/types": "*",

--- a/perf/perftest-inband-percent.js
+++ b/perf/perftest-inband-percent.js
@@ -1,5 +1,6 @@
 const Benchmark = require("benchmark");
 const Store = require("n3").Store;
+const {RdfStore} = require('rdf-stores');
 const rdfDereference = require("rdf-dereference").default;
 const NamedNode = require("n3").NamedNode;
 
@@ -12,10 +13,10 @@ Benchmark.options.maxTime = 2;
 
 let main = async function () {
   let suite = new Benchmark.Suite(undefined, {maxTime: 2});
-  let kboData = new Store();
-  let kboData130Quads = new Store();
-  let kboData1300Quads = new Store();
-  let shaclKBO = new Store();
+  let kboData = RdfStore.createDefault();
+  let kboData130Quads = RdfStore.createDefault();
+  let kboData1300Quads = RdfStore.createDefault();
+  let shaclKBO = RdfStore.createDefault();
   //Load the quads from the file
   let kboDataStream = (
       await rdfDereference.dereference("./perf/resources/kbo.ttl", {

--- a/perf/perftest-inband.js
+++ b/perf/perftest-inband.js
@@ -1,5 +1,5 @@
 const Benchmark = require("benchmark");
-const Store = require("n3").Store;
+const {RdfStore} = require('rdf-stores');
 const rdfDereference = require("rdf-dereference").default;
 const NamedNode = require("n3").NamedNode;
 
@@ -12,8 +12,8 @@ Benchmark.options.maxTime = 2;
 
 let main = async function () {
   let suite = new Benchmark.Suite(undefined, { maxTime: 2 });
-  let kboData = new Store();
-  let shaclKBO = new Store();
+  let kboData = RdfStore.createDefault();
+  let shaclKBO = RdfStore.createDefault();
   //Load the quads from the file
   let kboDataStream = (
     await rdfDereference.dereference("./perf/resources/kbo.ttl", {

--- a/perf/perftest-outband.js
+++ b/perf/perftest-outband.js
@@ -1,5 +1,5 @@
 const Benchmark = require("benchmark");
-const Store = require("n3").Store;
+const {RdfStore} = require('rdf-stores');
 const rdfDereference = require("rdf-dereference").default;
 const NamedNode = require("n3").NamedNode;
 const { performance } = require("perf_hooks");
@@ -47,10 +47,10 @@ const runBenchmarkInCleanContext = async (benchmarkName, benchmarkFn, timeout) =
 
 let main = async function () {
   let suite = new Benchmark.Suite();
-  let memberData = new Store();
-  let memberOutBandData = new Store();
-  let memberOutBandDataPartial = new Store();
-  let shaclmember = new Store();
+  let memberData = RdfStore.createDefault();
+  let memberOutBandData = RdfStore.createDefault();
+  let memberOutBandDataPartial = RdfStore.createDefault();
+  let shaclmember = RdfStore.createDefault();
 
   //Load the quads from the file
   let memberDataStream = (

--- a/tests/01 - fetching a shacl shape/extraction.test.ts
+++ b/tests/01 - fetching a shacl shape/extraction.test.ts
@@ -1,12 +1,13 @@
 import { assert } from "chai";
-import { NamedNode, Parser, Store, StreamParser, Term, Writer } from "n3";
+import { NamedNode, Parser, StreamParser, Term, Writer } from "n3";
+import { RdfStore } from "rdf-stores";
 import { CBDShapeExtractor } from "../../lib/CBDShapeExtractor";
 import rdfDereference from "rdf-dereference";
 
 describe("Check whether we can successfully extract a SHACL shape", async () => {
-  let shapeStore = new Store();
+  let shapeStore = RdfStore.createDefault();
   let extractor: CBDShapeExtractor;
-  let dataStore = new Store();
+  let dataStore = RdfStore.createDefault();
   before(async () => {
     let readStream = (
       await rdfDereference.dereference(

--- a/tests/01 - fetching a shacl shape/shapeTemplate.test.ts
+++ b/tests/01 - fetching a shacl shape/shapeTemplate.test.ts
@@ -1,9 +1,8 @@
-import { Store } from "n3";
 import { ShapesGraph } from "../../lib/Shape";
 import rdfDereference from "rdf-dereference";
-
+import { RdfStore } from "rdf-stores";
 describe("Test shape template of the SHACL SHACL", function () {
-  let shapeStore = new Store();
+  let shapeStore = RdfStore.createDefault();
   let shapesGraph: ShapesGraph;
   before(async () => {
     let readStream = (

--- a/tests/03 - CBD tests without a shape/without-shape.test.ts
+++ b/tests/03 - CBD tests without a shape/without-shape.test.ts
@@ -1,12 +1,13 @@
 import { assert } from "chai";
 import { NamedNode, Parser, Store, StreamParser, Term, Writer } from "n3";
 import { CBDShapeExtractor } from "../../lib/extract-cbd-shape";
+import { RdfStore } from "rdf-stores";
 import rdfDereference from "rdf-dereference";
 
 describe("Tests whether plain CBD works using the data from 01 and 02", function () {
   it("Example 01 should return 11 triples with CBD", async () => {
     let extractor = new CBDShapeExtractor();
-    let dataStore = new Store();
+    let dataStore = RdfStore.createDefault();
     let readStream = (
       await rdfDereference.dereference(
         "./tests/01 - fetching a shacl shape/shacl-catalog.ttl",
@@ -27,7 +28,7 @@ describe("Tests whether plain CBD works using the data from 01 and 02", function
   });
   it("Example 02 should return 2 triples with CBD", async () => {
     let extractor = new CBDShapeExtractor();
-    let dataStore = new Store();
+    let dataStore = RdfStore.createDefault();
     let readStream = (
       await rdfDereference.dereference(
         "./tests/02 - marine regions LDES/data.ttl",
@@ -51,7 +52,7 @@ describe("Tests whether plain CBD works using the data from 01 and 02", function
 describe("Test CBD with nested blank nodes", async () => {
   it("Should be able to process nested blank nodes", async () => {
     let extractor = new CBDShapeExtractor();
-    let dataStore = new Store();
+    let dataStore = RdfStore.createDefault();
     let readStream = (
       await rdfDereference.dereference(
         "./tests/03 - CBD tests without a shape/data.ttl",
@@ -75,7 +76,7 @@ describe("Test CBD with nested blank nodes", async () => {
 describe("Test CBD with named graph", () => {
   it("Should retrieve all triples within a graph", async () => {
     let extractor = new CBDShapeExtractor();
-    let dataStore = new Store();
+    let dataStore = RdfStore.createDefault();
     let readStream = (
       await rdfDereference.dereference(
         "./tests/03 - CBD tests without a shape/data.ttl",
@@ -96,7 +97,7 @@ describe("Test CBD with named graph", () => {
   });
   it("Should retrieve all triples within a graph and combine it with the triples found from CBD", async () => {
     let extractor = new CBDShapeExtractor();
-    let dataStore = new Store();
+    let dataStore = RdfStore.createDefault();
     let readStream = (
       await rdfDereference.dereference(
         "./tests/03 - CBD tests without a shape/data.ttl",
@@ -117,7 +118,7 @@ describe("Test CBD with named graph", () => {
   });
   it("Should retrieve only the quads from that particular update in an LDES", async () => {
     let extractor = new CBDShapeExtractor();
-    let dataStore = new Store();
+    let dataStore = RdfStore.createDefault();
     let readStream = (
       await rdfDereference.dereference(
         "./tests/03 - CBD tests without a shape/data.ttl",

--- a/tests/04 - logical edge cases/testExtraction.test.ts
+++ b/tests/04 - logical edge cases/testExtraction.test.ts
@@ -1,14 +1,15 @@
 import { assert } from "chai";
-import { NamedNode, Parser, Store, StreamParser, Term, Writer } from "n3";
+import { NamedNode, Parser, StreamParser, Term, Writer } from "n3";
+import { RdfStore } from "rdf-stores";
 import { CBDShapeExtractor } from "../../lib/CBDShapeExtractor";
 import rdfDereference from "rdf-dereference";
 
 describe("Extracting logical edge cases", function () {
   this.timeout(25000);
 
-  let shapeStore = new Store();
+  let shapeStore = RdfStore.createDefault();
   let extractor: CBDShapeExtractor;
-  let dataStore = new Store();
+  let dataStore = RdfStore.createDefault();
   before(async () => {
     let readStream = (
       await rdfDereference.dereference(

--- a/tests/04 - logical edge cases/testShapeTemplate.test.ts
+++ b/tests/04 - logical edge cases/testShapeTemplate.test.ts
@@ -3,17 +3,17 @@ import {
   DataFactory,
   NamedNode,
   Parser,
-  Store,
   StreamParser,
   Term,
   Writer,
 } from "n3";
+import { RdfStore } from "rdf-stores";
 import { ShapesGraph, ShapeTemplate } from "../../lib/Shape";
 import rdfDereference from "rdf-dereference";
 
 const { namedNode } = DataFactory;
 describe("Test shape template of the logical edge cases", function () {
-  let shapeStore = new Store();
+  let shapeStore = RdfStore.createDefault();
   let shapesGraph: ShapesGraph;
   before(async () => {
     let readStream = (

--- a/tests/05 - paths/extraction.test.ts
+++ b/tests/05 - paths/extraction.test.ts
@@ -2,11 +2,11 @@ import { assert } from "chai";
 import { NamedNode, Parser, Store, StreamParser, Term, Writer } from "n3";
 import { CBDShapeExtractor } from "../../lib/CBDShapeExtractor";
 import rdfDereference from "rdf-dereference";
-
+import { RdfStore } from "rdf-stores";
 describe("Check whether paths trigger the right extraction process", function () {
-  let shapeStore = new Store();
+  let shapeStore = RdfStore.createDefault();
   let extractor: CBDShapeExtractor;
-  let dataStore = new Store();
+  let dataStore = RdfStore.createDefault();
   before(async () => {
     let readStream = (
       await rdfDereference.dereference("./tests/05 - paths/shape.ttl", {

--- a/tests/05 - paths/pathPattern.test.ts
+++ b/tests/05 - paths/pathPattern.test.ts
@@ -4,9 +4,9 @@ import { ShapesGraph } from "../../lib/Shape";
 import rdfDereference from "rdf-dereference";
 import { CbdExtracted } from "../../lib/CBDShapeExtractor";
 const { namedNode } = DataFactory;
-
+import { RdfStore } from "rdf-stores";
 describe("Test whether the Patterns are correctly created", function () {
-  let shapeStore = new Store();
+  let shapeStore = RdfStore.createDefault();
   let shapesGraph: ShapesGraph;
   before(async () => {
     let readStream = (
@@ -27,8 +27,8 @@ describe("Test whether the Patterns are correctly created", function () {
 });
 
 describe("Test whether the Patterns are correctly matched", function () {
-  let shapeStore = new Store();
-  let store = new Store();
+  let shapeStore = RdfStore.createDefault();
+  let store = RdfStore.createDefault();
 
   let shapesGraph: ShapesGraph;
   before(async () => {

--- a/tests/05 - paths/shapeTemplate.test.ts
+++ b/tests/05 - paths/shapeTemplate.test.ts
@@ -1,11 +1,13 @@
 import { assert } from "chai";
-import { DataFactory, Store } from "n3";
+import { DataFactory } from "rdf-data-factory";
+import { RdfStore } from "rdf-stores";
 import { ShapesGraph, ShapeTemplate } from "../../lib/Shape";
 import rdfDereference from "rdf-dereference";
-const { namedNode } = DataFactory;
+
+const df = new DataFactory();
 
 describe("Test whether the SHACL template is well extracted based on paths", function () {
-  let shapeStore = new Store();
+  let shapeStore = RdfStore.createDefault();
   let shapesGraph: ShapesGraph;
   before(async () => {
     let readStream = (
@@ -23,7 +25,7 @@ describe("Test whether the SHACL template is well extracted based on paths", fun
 
   it("Check whether sequence paths are correctly represented", async () => {
     assert(
-      shapesGraph.shapes.get(namedNode("http://example.org/SequencePathShape")),
+      shapesGraph.shapes.get(df.namedNode("http://example.org/SequencePathShape")),
     );
   });
 });

--- a/tests/06 - shapes and named graphs/extraction-example.test.ts
+++ b/tests/06 - shapes and named graphs/extraction-example.test.ts
@@ -1,13 +1,14 @@
 import { assert } from "chai";
-import { NamedNode, Parser, Store, StreamParser, Term, Writer } from "n3";
 import { CBDShapeExtractor } from "../../lib/CBDShapeExtractor";
 import rdfDereference from "rdf-dereference";
 import { Quad, Term as RTerm } from "@rdfjs/types";
-
+import { RdfStore } from "rdf-stores";
+import { DataFactory } from "rdf-data-factory";
+const df = new DataFactory();
 describe("Check weather all selected quads can be extracted", function () {
-  let shapeStore = new Store();
+  let shapeStore = RdfStore.createDefault();
   let extractor: CBDShapeExtractor;
-  let dataStore = new Store();
+  let dataStore = RdfStore.createDefault();
   before(async () => {
     let readStream = (
       await rdfDereference.dereference(
@@ -36,8 +37,8 @@ describe("Check weather all selected quads can be extracted", function () {
   it("All quads from example should be extracted", async () => {
     let result = await extractor.extract(
       dataStore,
-      new NamedNode("http://example.org/line"),
-      new NamedNode("http://example.org/shape"),
+      df.namedNode("http://example.org/line"),
+      df.namedNode("http://example.org/shape"),
     );
     // It should only have 6 quads
     assert.equal(result.length, 6);
@@ -62,10 +63,10 @@ describe("Check weather all selected quads can be extracted", function () {
     let result = await extractor.bulkExtract(
       dataStore,
       [
-        new NamedNode("http://example.org/line"),
-        new NamedNode("http://example.org/important_point"),
+        df.namedNode("http://example.org/line"),
+        df.namedNode("http://example.org/important_point"),
       ],
-      new NamedNode("http://example.org/shape"),
+      df.namedNode("http://example.org/shape"),
       undefined,
       cb,
     );

--- a/tests/06 - shapes and named graphs/extraction.test.ts
+++ b/tests/06 - shapes and named graphs/extraction.test.ts
@@ -1,12 +1,13 @@
 import { assert } from "chai";
-import { NamedNode, Parser, Store, StreamParser, Term, Writer } from "n3";
+import { NamedNode, Parser, StreamParser, Term, Writer } from "n3";
 import { CBDShapeExtractor } from "../../lib/CBDShapeExtractor";
 import rdfDereference from "rdf-dereference";
+import { RdfStore } from "rdf-stores";
 
 describe("Check whether paths trigger the right extraction process", function () {
-  let shapeStore = new Store();
+  let shapeStore = RdfStore.createDefault();
   let extractor: CBDShapeExtractor;
-  let dataStore = new Store();
+  let dataStore = RdfStore.createDefault();
   before(async () => {
     let readStream = (
       await rdfDereference.dereference("./tests/06 - shapes and named graphs/shape.ttl", {


### PR DESCRIPTION
 * Using RdfStore instead of N3.Store. This will be interesting to test different indexes for performance and memory footprint, as we mainly use object look-up.
 * Switched as much as possible to RDFJS types, which is also required by RdfStore

Made this branch for https://github.com/pietercolpaert/DCAT-AP-Dumps-To-Feeds/issues/7