### PR TITLE
Fixing issue 22: zeroOrMorePaths should return all options, not just one

### DIFF
--- a/lib/Path.ts
+++ b/lib/Path.ts
@@ -211,6 +211,10 @@ export abstract class MultiPath implements Path {
       const newTargets: PathResult[] = [];
 
       for (const t of targets) {
+        if (this.filter(i, t)) {
+          out.push(t);
+        }
+
         for (const found of this.path.match(
           store,
           t.cbdExtracted,
@@ -218,14 +222,11 @@ export abstract class MultiPath implements Path {
           graphsToIgnore,
           inverse,
         )) {
-          if (this.filter(i, found)) {
-            out.push({
-              path: [...t.path, ...found.path],
-              cbdExtracted: t.cbdExtracted,
-              target: found.target,
-            });
-          }
-          newTargets.push(found);
+          newTargets.push({
+            path: [...t.path, ...found.path],
+            cbdExtracted: t.cbdExtracted,
+            target: found.target,
+          });
         }
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "extract-cbd-shape",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "extract-cbd-shape",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@treecg/types": "^0.4.5",

--- a/tests/05 - paths/extraction.test.ts
+++ b/tests/05 - paths/extraction.test.ts
@@ -81,6 +81,15 @@ describe("Check whether paths trigger the right extraction process", function ()
     //writer.end((err, res) => {console.error(res);});
     assert.equal(result.length, 2);
   });
+  it("Test a zeroOrMore path where zero and multiple both match", async () => {
+    let result = await extractor.extract(
+      dataStore,
+      new NamedNode("http://example.org/B"),
+      new NamedNode("http://example.org/ZeroOrMorePathShape2"),
+    );
+    //ISSUE 22: the triple ex:B ex:p2 ex:C also matches the zeroOrMorePath, but this is not being returned
+    assert.equal(result.length, 3);
+  });
   it("Test a oneOrMore path", async () => {
     let result = await extractor.extract(
       dataStore,

--- a/tests/05 - paths/shape.ttl
+++ b/tests/05 - paths/shape.ttl
@@ -56,6 +56,12 @@ ex:ZeroOrOnePathShape a sh:NodeShape ;
         sh:minCount 1
     ] .
 
+ex:ZeroOrMorePathShape2 a sh:NodeShape ;
+    sh:closed true;
+    sh:property [
+        sh:path ([sh:zeroOrMorePath ex:p1 ] ex:p2) ;
+    ] .
+
 ex:AlternativePathShape a sh:NodeShape ;
     sh:closed true;
     sh:property [


### PR DESCRIPTION
This PR currently contains a test that fails that should work