### PR TITLE
Mock fetch in unit tests to not rely on external sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "extract-cbd-shape",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "extract-cbd-shape",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "@treecg/types": "^0.4.5",
@@ -32,6 +32,7 @@
         "mocha": "^10.2.0",
         "pako": "^2.1.0",
         "rollup-plugin-polyfill-node": "^0.12.0",
+        "sinon": "^19.0.2",
         "systeminformation": "^5.21.20",
         "ts-node": "^10.9.1",
         "typescript": "5.5.4"
@@ -643,6 +644,55 @@
       "engines": {
         "node": ">=v12.22.12"
       }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/commons/node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true,
+      "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@treecg/types": {
       "version": "0.4.6",
@@ -1879,6 +1929,13 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1899,6 +1956,14 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -2094,6 +2159,20 @@
         "node": ">=12.0"
       }
     },
+    "node_modules/nise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.1.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -2204,6 +2283,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/pathval": {
@@ -2516,23 +2605,6 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
-    "node_modules/rollup": {
-      "version": "3.29.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
-      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=14.18.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/rollup-plugin-polyfill-node": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.12.0.tgz",
@@ -2587,6 +2659,48 @@
       "dependencies": {
         "@rdfjs/types": "^1.1.0",
         "n3": "^1.16.3"
+      }
+    },
+    "node_modules/sinon": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
+      "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.2",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "nise": "^6.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/source-map-js": {
@@ -2724,10 +2838,11 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "node_modules/systeminformation": {
-      "version": "5.23.5",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.23.5.tgz",
-      "integrity": "sha512-PEpJwhRYxZgBCAlWZhWIgfMTjXLqfcaZ1pJsJn9snWNfBW/Z1YQg1mbIUSWrEV3ErAHF7l/OoVLQeaZDlPzkpA==",
+      "version": "5.25.11",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.25.11.tgz",
+      "integrity": "sha512-jI01fn/t47rrLTQB0FTlMCC+5dYx8o0RRF+R4BPiUNsvg5OdY0s9DKMFmJGrx5SwMZQ4cag0Gl6v8oycso9b/g==",
       "dev": true,
+      "license": "MIT",
       "os": [
         "darwin",
         "linux",

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   "license": "MIT",
   "dependencies": {
     "@treecg/types": "^0.4.5",
-    "rdf-dereference": "4.x",
     "debug": "^4.3.4",
     "jsdom": "^23.0.1",
     "n3": "^1.23.1",
     "rdf-data-factory": "^1.1.2",
+    "rdf-dereference": "4.x",
     "rdf-stores": "^1.0.0"
   },
   "devDependencies": {
@@ -42,8 +42,9 @@
     "mocha": "^10.2.0",
     "pako": "^2.1.0",
     "rollup-plugin-polyfill-node": "^0.12.0",
+    "sinon": "^19.0.2",
     "systeminformation": "^5.21.20",
-    "typescript": "5.5.4",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "typescript": "5.5.4"
   }
 }

--- a/tests/02 - marine regions LDES/mrg.test.ts
+++ b/tests/02 - marine regions LDES/mrg.test.ts
@@ -1,48 +1,133 @@
-import { assert } from "chai";
-import { DataFactory } from "rdf-data-factory";
-import { RdfStore } from "rdf-stores";
-import { CBDShapeExtractor } from "../../lib/extract-cbd-shape";
+import {assert} from "chai";
+import {DataFactory} from "rdf-data-factory";
+import {RdfStore} from "rdf-stores";
+import {CBDShapeExtractor} from "../../lib/extract-cbd-shape";
 import {rdfDereferencer} from "rdf-dereference";
-import { TREE } from "@treecg/types";
+import sinon, {SinonStub} from "sinon";
+
 const df = new DataFactory();
 describe("Check whether a member from the MRG source can be fully extracted", function () {
-  this.timeout(25000);
-  it("Extract a shape from MRG and check whether it successfully did a call to a geometry it needs", async () => {
-    let shapeStore =RdfStore.createDefault();
-    let readStream = (
-      await rdfDereferencer.dereference(
-        "./tests/02 - marine regions LDES/shacl.ttl",
-        { localFiles: true },
-      )
-    ).data;
-    await new Promise((resolve, reject) => {
-      shapeStore.import(readStream).on("end", resolve).on("error", reject);
-    });
-    let extractor = new CBDShapeExtractor(shapeStore);
-    let dataStore =RdfStore.createDefault();
-    let readStream2 = (
-      await rdfDereferencer.dereference(
-        "./tests/02 - marine regions LDES/data.ttl",
-        { localFiles: true },
-      )
-    ).data;
-    await new Promise((resolve, reject) => {
-      dataStore.import(readStream2).on("end", resolve).on("error", reject);
-    });
-    let result = await extractor.extract(
-      dataStore,
-      df.namedNode("http://marineregions.org/mrgid/24983?t=1690208097"),
-      df.namedNode("http://example.org/shape"),
-    );
+   let fetchStub: SinonStub;
 
-    assert.equal(
-      result.filter((quad) => {
-        return (
-          quad.subject.value ===
-          "http://marineregions.org/mrgid/24983/geometries?source=110&attributeValue=2004"
-        );
-      }).length,
-      2,
-    ); // Test whether it actually did a call
-  });
+   before(() => {
+      // Mock the global fetch function
+      fetchStub = sinon.stub(global, "fetch");
+
+      // Mock response for the specific MRG member URL
+      fetchStub
+         .withArgs("http://marineregions.org/mrgid/24983")
+         .resolves(
+            new Response(
+               `
+@prefix mr: <http://marineregions.org/ns/ontology#> .
+@prefix mrt: <http://marineregions.org/ns/placetypes#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix gsp: <http://www.opengis.net/ont/geosparql#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://marineregions.org/mrgid/24983>
+  a mr:MRGeoObject, mrt:Escarpment ;
+  mr:hasGeometry <http://marineregions.org/mrgid/24983/geometries?source=110&attributeValue=2004> ;
+  mr:isPartOf <http://marineregions.org/mrgid/4300>, <http://marineregions.org/mrgid/8487> ;
+  dc:modified "2023-07-24T14:14:57Z"^^xsd:dateTime ;
+  skos:altLabel "Minami Amami Escarpment"@en, "Minami Anami Escarpment"@en ;
+  skos:prefLabel "Minami-Amami Escarpment"@en ;
+  dcat:bbox "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POLYGON ((133.4 27.5,133.4 27.5,133.4 27,133.4 27,133.4 27.5))"^^gsp:wktLiteral ;
+  dcat:centroid "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT (133.4 27.25)"^^gsp:wktLiteral ;
+  prov:hadPrimarySource <http://www.ngdc.noaa.gov/gazetteer/> .
+
+<http://marineregions.org/mrgid/4300>
+  a mr:MRGeoObject, mrt:IHOSeaArea ;
+  skos:prefLabel "Philippine Sea"@en .
+
+<http://marineregions.org/mrgid/8487>
+  a mr:MRGeoObject, mrt:EEZ ;
+  skos:prefLabel "Japanese Exclusive Economic Zone"@en .
+
+<http://www.ngdc.noaa.gov/gazetteer/> rdfs:label "IHO-IOC GEBCO Gazetteer of Undersea Feature Names"^^xsd:string .
+          `,
+               {
+                  status: 200,
+                  headers: {"Content-Type": "text/turtle"},
+               }
+            )
+         );
+
+      // Mock response for the specific MRG geometry URL
+      fetchStub
+         .withArgs("http://marineregions.org/mrgid/24983/geometries?source=110&attributeValue=2004")
+         .resolves(
+            new Response(
+               `
+@prefix mr: <http://marineregions.org/ns/ontology#> .
+@prefix gsp: <http://www.opengis.net/ont/geosparql#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://marineregions.org/mrgid/24983> mr:hasGeometry <http://marineregions.org/mrgid/24983/geometries?source=110&attributeValue=2004> .
+<http://marineregions.org/mrgid/24983/geometries?source=110&attributeValue=2004>
+  gsp:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> LINESTRING (133.4 27, 133.4 27.5)"^^gsp:wktLiteral ;
+  prov:hadPrimarySource <http://www.ngdc.noaa.gov/gazetteer/> .
+
+<http://www.ngdc.noaa.gov/gazetteer/> rdfs:label "IHO-IOC GEBCO Gazetteer of Undersea Feature Names"^^xsd:string .
+             `,
+               {
+                  status: 200,
+                  headers: {"Content-Type": "text/turtle"},
+               }
+            )
+         );
+   });
+
+   after(() => {
+      // Restore the original fetch function
+      fetchStub.restore();
+   });
+
+   it("Extract a shape from MRG and check whether it successfully did a call to a geometry it needs", async () => {
+      let shapeStore = RdfStore.createDefault();
+      let readStream = (
+         await rdfDereferencer.dereference(
+            "./tests/02 - marine regions LDES/shacl.ttl",
+            {localFiles: true},
+         )
+      ).data;
+      await new Promise((resolve, reject) => {
+         shapeStore.import(readStream).on("end", resolve).on("error", reject);
+      });
+      let extractor = new CBDShapeExtractor(shapeStore);
+      let dataStore = RdfStore.createDefault();
+      let readStream2 = (
+         await rdfDereferencer.dereference(
+            "./tests/02 - marine regions LDES/data.ttl",
+            {localFiles: true},
+         )
+      ).data;
+      await new Promise((resolve, reject) => {
+         dataStore.import(readStream2).on("end", resolve).on("error", reject);
+      });
+      let result = await extractor.extract(
+         dataStore,
+         df.namedNode("http://marineregions.org/mrgid/24983?t=1690208097"),
+         df.namedNode("http://example.org/shape"),
+      );
+
+      assert(fetchStub.calledWith("http://marineregions.org/mrgid/24983"));
+      assert(fetchStub.calledWith("http://marineregions.org/mrgid/24983/geometries?source=110&attributeValue=2004"));
+
+      assert.equal(
+         result.filter((quad) => {
+            return (
+               quad.subject.value ===
+               "http://marineregions.org/mrgid/24983/geometries?source=110&attributeValue=2004"
+            );
+         }).length,
+         2,
+      ); // Test whether it actually did a call
+   });
 });

--- a/tests/04 - logical edge cases/data.ttl
+++ b/tests/04 - logical edge cases/data.ttl
@@ -11,9 +11,9 @@ ex:Person2 a ex:Person ;
     ex:name "Person 2" ;
     ex:knows ex:Person1.
 
-ex:Person3 a ex:Person; 
+ex:Person3 a ex:Person;
     ex:name "Person 3";
-    ex:knows <https://raw.githubusercontent.com/pietercolpaert/extract-cbd-shape/main/tests/04%20-%20logical%20edge%20cases/name.ttl#Person1> .
+    ex:knows <https://test.com/name.ttl#Person1> .
 
 ex:Person4 a ex:Person ;
     ex:qualifiedName ex:NamePerson4 .
@@ -23,8 +23,8 @@ ex:NamePerson4  ex:name "Person 4" .
 
 ## This one, if configured with ex:TriggersHTTPShape, will trigger an HTTP request to be done
 
-ex:Person5 a ex:Person; 
-    ex:qualifiedName <https://raw.githubusercontent.com/pietercolpaert/extract-cbd-shape/main/tests/04%20-%20logical%20edge%20cases/name.ttl> .
+ex:Person5 a ex:Person;
+    ex:qualifiedName <https://test.com/name.ttl> .
 
 ex:Person6 a ex:Person ;
     ex:name "Person6" ;

--- a/tests/04 - logical edge cases/name.ttl
+++ b/tests/04 - logical edge cases/name.ttl
@@ -1,6 +1,0 @@
-@prefix ex: <http://example.org/> .
-@prefix foaf: <http://xmlns.com/foaf/0.1/>.
-
-<./name.ttl> ex:name "Pieter" .
-
-<https://raw.githubusercontent.com/pietercolpaert/extract-cbd-shape/main/tests/04%20-%20logical%20edge%20cases/name.ttl#Person1> ex:name "Peterson" .

--- a/tests/04 - logical edge cases/testExtraction.test.ts
+++ b/tests/04 - logical edge cases/testExtraction.test.ts
@@ -1,106 +1,135 @@
-import { assert } from "chai";
-import { NamedNode, Parser, StreamParser, Term, Writer } from "n3";
-import { RdfStore } from "rdf-stores";
-import { CBDShapeExtractor } from "../../lib/CBDShapeExtractor";
+import {assert} from "chai";
+import {NamedNode, Parser} from "n3";
+import {RdfStore} from "rdf-stores";
+import {CBDShapeExtractor} from "../../lib/CBDShapeExtractor";
 import {rdfDereferencer} from "rdf-dereference";
+import sinon, {SinonStub} from "sinon";
 
 describe("Extracting logical edge cases", function () {
-  this.timeout(25000);
+   let fetchStub: SinonStub;
 
-  let shapeStore = RdfStore.createDefault();
-  let extractor: CBDShapeExtractor;
-  let dataStore = RdfStore.createDefault();
-  before(async () => {
-    let readStream = (
-      await rdfDereferencer.dereference(
-        "./tests/04 - logical edge cases/shape.ttl",
-        { localFiles: true },
-      )
-    ).data;
-    await new Promise((resolve, reject) => {
-      shapeStore.import(readStream).on("end", resolve).on("error", reject);
-    });
-    extractor = new CBDShapeExtractor(shapeStore);
-    let readStream2 = (
-      await rdfDereferencer.dereference(
-        "./tests/04 - logical edge cases/data.ttl",
-        { localFiles: true },
-      )
-    ).data;
-    await new Promise((resolve, reject) => {
-      dataStore.import(readStream2).on("end", resolve).on("error", reject);
-    });
-  });
-  it("Check whether the OR condition works - and check with recursion", async () => {
-    let result = await extractor.extract(
-      dataStore,
-      new NamedNode("http://example.org/Person1"),
-      new NamedNode("http://example.org/Shape"),
-    );
-    //let writer = new Writer();
-    //writer.addQuads(result);
-    //writer.end((err, res) => {console.log(res);});
-    assert.equal(result.length, 7);
-  });
-  it("Check whether the OR condition works a second time as well", async () => {
-    let result = await extractor.extract(
-      dataStore,
-      new NamedNode("http://example.org/Person2"),
-      new NamedNode("http://example.org/PersonShape"),
-    );
-    //let writer = new Writer();
-    //writer.addQuads(result);
-    //writer.end((err, res) => {console.log(res);});
-    assert.equal(result.length, 7);
-  });
-  it("Check whether it does an HTTP request if it doesn’t find the required properties on a node", async () => {
-    let result = await extractor.extract(
-      dataStore,
-      new NamedNode("http://example.org/Person3"),
-      new NamedNode("http://example.org/KnowsPieterShape"),
-    );
-    //let writer = new Writer();
-    //writer.addQuads(result);
-    //writer.end((err, res) => {console.log(res);});
-    assert.equal(result.length, 4);
-  });
-  it("Check whether it finds the nodelink in a xone", async () => {
-    let result = await extractor.extract(
-      dataStore,
-      new NamedNode("http://example.org/Person4"),
-      new NamedNode("http://example.org/XoneWithNodeShape"),
-    );
-    //let writer = new Writer();
-    //writer.addQuads(result);
-    //writer.end((err, res) => {console.log(res);});
-    assert.equal(result.length, 3);
-  });
-  it("Check whether a node link in a xone in a xone triggers an HTTP request", async () => {
-    let result = await extractor.extract(
-      dataStore,
-      new NamedNode("http://example.org/Person5"),
-      new NamedNode("http://example.org/TriggersHTTPShape"),
-    );
-    //let writer = new Writer();
-    //writer.addQuads(result);
-    //writer.end((err, res) => {console.log(res);});
-    assert.equal(result.length, 3);
-  });
-  it("Check whether a circular XONE shape works", async () => {
-    let result = await extractor.extract(
-      dataStore,
-      new NamedNode("http://example.org/Person6"),
-      new NamedNode("http://example.org/CircularXoneShape"),
-    );
-    //let writer = new Writer();
-    //writer.addQuads(result);
-    //writer.end((err, res) => {console.log(res);});
-    assert.equal(result.length, 7);
-  });
+   let shapeStore = RdfStore.createDefault();
+   let extractor: CBDShapeExtractor;
+   let dataStore = RdfStore.createDefault();
+   before(async () => {
+      // Mock the global fetch function
+      fetchStub = sinon.stub(global, "fetch");
+
+      // Mock response for the specific person URL
+      fetchStub
+         .withArgs("https://test.com/name.ttl")
+         .withArgs("https://test.com/name.ttl#Person1")
+         .resolves(
+            new Response(`
+@prefix ex: <http://example.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+<./name.ttl> ex:name "Pieter" .
+
+<https://test.com/name.ttl#Person1> ex:name "Peterson" .
+            `,
+               {
+                  status: 200,
+                  headers: {"Content-Type": "text/turtle"},
+               }
+            )
+         );
+      let readStream = (
+         await rdfDereferencer.dereference(
+            "./tests/04 - logical edge cases/shape.ttl",
+            {localFiles: true},
+         )
+      ).data;
+      await new Promise((resolve, reject) => {
+         shapeStore.import(readStream).on("end", resolve).on("error", reject);
+      });
+      extractor = new CBDShapeExtractor(shapeStore);
+      let readStream2 = (
+         await rdfDereferencer.dereference(
+            "./tests/04 - logical edge cases/data.ttl",
+            {localFiles: true},
+         )
+      ).data;
+      await new Promise((resolve, reject) => {
+         dataStore.import(readStream2).on("end", resolve).on("error", reject);
+      });
+   });
+
+   after(() => {
+      // Restore the original fetch function
+      fetchStub.restore();
+   });
+
+   it("Check whether the OR condition works - and check with recursion", async () => {
+      let result = await extractor.extract(
+         dataStore,
+         new NamedNode("http://example.org/Person1"),
+         new NamedNode("http://example.org/Shape"),
+      );
+      //let writer = new Writer();
+      //writer.addQuads(result);
+      //writer.end((err, res) => {console.log(res);});
+      assert.equal(result.length, 7);
+   });
+   it("Check whether the OR condition works a second time as well", async () => {
+      let result = await extractor.extract(
+         dataStore,
+         new NamedNode("http://example.org/Person2"),
+         new NamedNode("http://example.org/PersonShape"),
+      );
+      //let writer = new Writer();
+      //writer.addQuads(result);
+      //writer.end((err, res) => {console.log(res);});
+      assert.equal(result.length, 7);
+   });
+   it("Check whether it does an HTTP request if it doesn’t find the required properties on a node", async () => {
+      let result = await extractor.extract(
+         dataStore,
+         new NamedNode("http://example.org/Person3"),
+         new NamedNode("http://example.org/KnowsPieterShape"),
+      );
+      //let writer = new Writer();
+      //writer.addQuads(result);
+      //writer.end((err, res) => {console.log(res);});
+      assert.equal(result.length, 4);
+   });
+   it("Check whether it finds the nodelink in a xone", async () => {
+      let result = await extractor.extract(
+         dataStore,
+         new NamedNode("http://example.org/Person4"),
+         new NamedNode("http://example.org/XoneWithNodeShape"),
+      );
+      //let writer = new Writer();
+      //writer.addQuads(result);
+      //writer.end((err, res) => {console.log(res);});
+      assert.equal(result.length, 3);
+   });
+   it("Check whether a node link in a xone in a xone triggers an HTTP request", async () => {
+      let result = await extractor.extract(
+         dataStore,
+         new NamedNode("http://example.org/Person5"),
+         new NamedNode("http://example.org/TriggersHTTPShape"),
+      );
+      //let writer = new Writer();
+      //writer.addQuads(result);
+      //writer.end((err, res) => {console.log(res);});
+      assert.equal(result.length, 3);
+   });
+   it("Check whether a circular XONE shape works", async () => {
+      let result = await extractor.extract(
+         dataStore,
+         new NamedNode("http://example.org/Person6"),
+         new NamedNode("http://example.org/CircularXoneShape"),
+      );
+      //let writer = new Writer();
+      //writer.addQuads(result);
+      //writer.end((err, res) => {console.log(res);});
+      assert.equal(result.length, 7);
+   });
 });
 
 describe("Check whether paths are correctly chained", async () => {
-  const shape = `
+   const shape = `
 @prefix sh:  <http://www.w3.org/ns/shacl#> .
 @prefix ex:  <http://example.org/> .
 
@@ -118,7 +147,7 @@ ex:outerShape
 	] .
 `;
 
-  const data = `
+   const data = `
 @prefix ex:  <http://example.org/> .
 
 ex:false ex:second "Don't find me".
@@ -130,29 +159,29 @@ ex:subject ex:first ex:false;
   ex:inner ex:true.
 `;
 
-  let shapeStore = RdfStore.createDefault();
-  let extractor: CBDShapeExtractor;
-  let dataStore = RdfStore.createDefault();
+   let shapeStore = RdfStore.createDefault();
+   let extractor: CBDShapeExtractor;
+   let dataStore = RdfStore.createDefault();
 
-  const shapeQuads = new Parser().parse(shape);
-  const dataQuads = new Parser().parse(data);
+   const shapeQuads = new Parser().parse(shape);
+   const dataQuads = new Parser().parse(data);
 
-  shapeQuads.forEach((quad) => shapeStore.addQuad(quad));
-  dataQuads.forEach((quad) => dataStore.addQuad(quad));
-  extractor = new CBDShapeExtractor(shapeStore);
+   shapeQuads.forEach((quad) => shapeStore.addQuad(quad));
+   dataQuads.forEach((quad) => dataStore.addQuad(quad));
+   extractor = new CBDShapeExtractor(shapeStore);
 
-  const entity = await extractor.extract(
-    dataStore,
-    new NamedNode("http://example.org/subject"),
-    new NamedNode("http://example.org/outerShape"),
-  );
-  it("Follows complex path inside inner node", async () => {
-    const findMe = entity.find((q) => q.object.value === "Find me");
-    assert.isTrue(!!findMe, "Find me is found");
-  });
+   const entity = await extractor.extract(
+      dataStore,
+      new NamedNode("http://example.org/subject"),
+      new NamedNode("http://example.org/outerShape"),
+   );
+   it("Follows complex path inside inner node", async () => {
+      const findMe = entity.find((q) => q.object.value === "Find me");
+      assert.isTrue(!!findMe, "Find me is found");
+   });
 
-  it("Doesn't follow path if it is not part of the shape", async () => {
-    const findMe = entity.find((q) => q.object.value === "Don't find me");
-    assert.isTrue(!findMe, "Don't find me is not found");
-  });
+   it("Doesn't follow path if it is not part of the shape", async () => {
+      const findMe = entity.find((q) => q.object.value === "Don't find me");
+      assert.isTrue(!findMe, "Don't find me is not found");
+   });
 });


### PR DESCRIPTION
The MRG LDES sometimes tends to be unreliable causing failing tests while they shouldn't.
Not relying on external sources, but mocking the fetch instead, also speeds up the tests themselves and removes the need for the custom higher timeout configuration.